### PR TITLE
Add state helper and media mapper tests

### DIFF
--- a/src/MediaOrganizer.Storage.Local/test/MediaOrganizer.Storage.Local.Tests/MediaFileMapperTests.cs
+++ b/src/MediaOrganizer.Storage.Local/test/MediaOrganizer.Storage.Local.Tests/MediaFileMapperTests.cs
@@ -1,0 +1,80 @@
+using MediaOrganizer.Core;
+using MediaOrganizer.Storage.Local;
+using System;
+using System.IO;
+using Xunit;
+
+namespace MediaOrganizer.Storage.Local.Tests;
+
+public class MediaFileMapperTests
+{
+    [Fact]
+    public void TryGetDestination_UsesAllCategories()
+    {
+        RunInTempDirectory(root =>
+        {
+            var sourceRoot = Path.Combine(root, "source");
+            var destRoot = Path.Combine(root, "dest");
+
+            var options = new FilesOrganizerOptions
+            {
+                DestinationRoot = destRoot,
+                DestinationPattern = "{Year}"
+            };
+            options.MediaCategories.Add(new MediaCategory { CategoryName = "Photos", CategoryRoot = "pics", FileExtensions = [".jpg"] });
+            options.MediaCategories.Add(new MediaCategory { CategoryName = "Videos", CategoryRoot = "vids", FileExtensions = [".mp4"] });
+
+            var mapper = new MediaFileMapper(options);
+
+            var photo = CreateTempFile(sourceRoot, "image.jpg");
+            File.SetCreationTime(photo, new DateTime(2024, 1, 1));
+
+            var result = mapper.TryGetDestination(photo, out var destination);
+            Assert.True(result);
+            Assert.Equal(Path.Combine(destRoot, "pics", "2024", "image.jpg"), destination);
+
+            var video = CreateTempFile(sourceRoot, "movie.mp4");
+            File.SetCreationTime(video, new DateTime(2025, 2, 2));
+            result = mapper.TryGetDestination(video, out destination);
+            Assert.True(result);
+            Assert.Equal(Path.Combine(destRoot, "vids", "2025", "movie.mp4"), destination);
+        });
+    }
+
+    [Fact]
+    public void TryGetDestination_ReturnsFalse_WhenNoCategoryMatches()
+    {
+        var options = new FilesOrganizerOptions { DestinationRoot = "dest", DestinationPattern = "{Year}" };
+        options.MediaCategories.Add(new MediaCategory { CategoryName = "Photos", CategoryRoot = "pics", FileExtensions = [".jpg"] });
+
+        var mapper = new MediaFileMapper(options);
+        var file = Path.Combine(Path.GetTempPath(), "doc.txt");
+
+        var result = mapper.TryGetDestination(file, out _);
+        Assert.False(result);
+    }
+
+    private static string CreateTempFile(string root, string name)
+    {
+        Directory.CreateDirectory(root);
+        var path = Path.Combine(root, name);
+        File.WriteAllText(path, "content");
+        return path;
+    }
+
+    private static void RunInTempDirectory(Action<string> test)
+    {
+        var dir = GetTempDirectory();
+        Directory.CreateDirectory(dir);
+        try
+        {
+            test(dir);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    private static string GetTempDirectory() => Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+}

--- a/src/MediaOrganizer/test/MediaOrganizer.Tests/FileOrganizerOptionsStateHelperTests.cs
+++ b/src/MediaOrganizer/test/MediaOrganizer.Tests/FileOrganizerOptionsStateHelperTests.cs
@@ -1,0 +1,77 @@
+using MediaOrganizer.Core;
+using MediaOrganizer.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MediaOrganizer.Tests;
+
+public class FileOrganizerOptionsStateHelperTests
+{
+    private class FakeAppStateManager : IAppStateManager
+    {
+        public readonly Dictionary<string, string> State = new();
+
+        public Task BeginLoadState() => Task.CompletedTask;
+        public Task SaveStateAsync() => Task.CompletedTask;
+
+        public Task<T> GetState<T>(string key)
+        {
+            if (State.TryGetValue(key, out var value))
+            {
+                object result = null;
+                if (typeof(T) == typeof(string))
+                    result = value;
+                else if (typeof(T) == typeof(bool))
+                    result = bool.Parse(value);
+                else if (typeof(T) == typeof(string[]))
+                    result = value.Split(IAppStateManager.ArrayElementsSeparator, StringSplitOptions.RemoveEmptyEntries);
+                return Task.FromResult((T)result);
+            }
+            return Task.FromResult(default(T));
+        }
+
+        public void UpdateState<T>(string key, T state)
+        {
+            if (state is string[] array)
+                State[key] = string.Join(IAppStateManager.ArrayElementsSeparator, array);
+            else
+                State[key] = state?.ToString();
+        }
+    }
+
+    [Fact]
+    public async Task SaveAndLoadOptions_WithMultipleCategories()
+    {
+        // Arrange
+        var options = new FilesOrganizerOptions
+        {
+            SourceRoot = "src",
+            DestinationRoot = "dest",
+            RemoveSource = true,
+            SkipExistingFiles = false,
+            DestinationPattern = "{Year}",
+            DeleteEmptyFolders = true
+        };
+        options.MediaCategories.Add(new MediaCategory { CategoryName = "photos", CategoryRoot = "pics", FileExtensions = [".jpg"] });
+        options.MediaCategories.Add(new MediaCategory { CategoryName = "videos", CategoryRoot = "vids", FileExtensions = [".mp4"] });
+
+        var stateManager = new FakeAppStateManager();
+
+        // Act
+        FileOrganizerOptionsStateHelper.SaveFileOrganizerOptionsState(stateManager, options);
+        var loaded = await FileOrganizerOptionsStateHelper.GetFileOrganizerOptionsAsync(stateManager);
+
+        // Assert
+        Assert.Equal(options.SourceRoot, loaded.SourceRoot);
+        Assert.Equal(options.DestinationRoot, loaded.DestinationRoot);
+        Assert.Equal(options.RemoveSource, loaded.RemoveSource);
+        Assert.Equal(options.SkipExistingFiles, loaded.SkipExistingFiles);
+        Assert.Equal(options.DestinationPattern, loaded.DestinationPattern);
+        Assert.Equal(options.DeleteEmptyFolders, loaded.DeleteEmptyFolders);
+        Assert.Equal(2, loaded.MediaCategories.Count);
+        Assert.Contains(loaded.MediaCategories, c => c.CategoryName == "photos" && c.CategoryRoot == "pics" && c.FileExtensions.SequenceEqual([".jpg"]));
+        Assert.Contains(loaded.MediaCategories, c => c.CategoryName == "videos" && c.CategoryRoot == "vids" && c.FileExtensions.SequenceEqual([".mp4"]));
+    }
+}

--- a/src/MediaOrganizer/test/MediaOrganizer.Tests/MediaOrganizer.Tests.csproj
+++ b/src/MediaOrganizer/test/MediaOrganizer.Tests/MediaOrganizer.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net9.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="6.0.2" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="Moq" Version="4.20.72" />
+		<PackageReference Include="xunit" Version="2.9.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+	</ItemGroup>
+
+	<ItemGroup>
+          <ProjectReference Include="..\src\MediaOrganizer.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Using Include="Xunit" />
+	</ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- cover options persistence across multiple categories
- verify MediaFileMapper handles each configured category
- add new test project for app-level helpers

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9a756ba083209c49d2f2536124bb