### PR TITLE
Preserve capture date when organizing media

### DIFF
--- a/src/MediaOrganizer.Storage.Local/src/ExifCreationDateExtractor.cs
+++ b/src/MediaOrganizer.Storage.Local/src/ExifCreationDateExtractor.cs
@@ -7,6 +7,20 @@ namespace MediaOrganizer.Storage.Local;
 
 internal sealed class ExifCreationDateExtractor : FileInfoBasedCreationDateExtractor
 {
+    private static readonly string[] SupportedTagNames =
+    [
+        "Date/Time Original",
+        "Date/Time Digitized",
+        "Date/Time",
+        "File Modified Date"
+    ];
+
+    private static readonly string[] OffsetAwareFormats =
+    [
+        "ddd MMM dd HH:mm:ss zzz yyyy",
+        "ddd MMM d HH:mm:ss zzz yyyy"
+    ];
+
     public ExifCreationDateExtractor()
     {
     }
@@ -18,38 +32,46 @@ internal sealed class ExifCreationDateExtractor : FileInfoBasedCreationDateExtra
         {
             foreach (var tag in item.Tags)
             {
-                if (tag.Name.Equals("Date/Time Original", StringComparison.OrdinalIgnoreCase) ||
-                    tag.Name.Equals("Date/Time Digitized", StringComparison.OrdinalIgnoreCase) ||
-                    tag.Name.Equals("Date/Time", StringComparison.OrdinalIgnoreCase) ||
-                    tag.Name.Equals("File Modified Date", StringComparison.OrdinalIgnoreCase))
+                if (SupportedTagNames.Contains(tag.Name, StringComparer.OrdinalIgnoreCase) &&
+                    TryParseMetadataTimestamp(tag.Description, out var captureDate))
                 {
-                    // Try EXIF numeric format first (e.g. "2025:04:08 19:37:09")
-                    if (DateTime.TryParseExact(tag.Description, "yyyy:MM:dd HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var originalDate))
-                    {
-                        return originalDate.ToUniversalTime();
-                    }
-
-                    // Exact parse for textual offset-aware formats like: "Tue Apr 08 19:37:09 -07:00 2025"
-                    var formats = new[]
-                    {
-                        "ddd MMM dd HH:mm:ss zzz yyyy",
-                        "ddd MMM d HH:mm:ss zzz yyyy"
-                    };
-
-                    if (DateTimeOffset.TryParseExact(tag.Description, formats, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dto))
-                    {
-                        return dto.UtcDateTime;
-                    }
-
-                    // Final fallback: a general DateTimeOffset parse (less strict)
-                    if (DateTimeOffset.TryParse(tag.Description, CultureInfo.InvariantCulture, DateTimeStyles.None, out dto))
-                    {
-                        return dto.UtcDateTime;
-                    }
+                    return captureDate;
                 }
             }
         }
 
         return base.ExtractCreationDate(file);
+    }
+
+    internal static bool TryParseMetadataTimestamp(string value, out DateTime captureDate)
+    {
+        captureDate = default;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        // EXIF numeric timestamps typically do not carry timezone information,
+        // so preserve the recorded calendar date instead of treating it as UTC.
+        if (DateTime.TryParseExact(value, "yyyy:MM:dd HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out var originalDate))
+        {
+            captureDate = DateTime.SpecifyKind(originalDate, DateTimeKind.Unspecified);
+            return true;
+        }
+
+        if (DateTimeOffset.TryParseExact(value, OffsetAwareFormats, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dto))
+        {
+            captureDate = dto.DateTime;
+            return true;
+        }
+
+        if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out dto))
+        {
+            captureDate = dto.DateTime;
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/MediaOrganizer.Storage.Local/src/FileInfoBasedCreationDateExtractor.cs
+++ b/src/MediaOrganizer.Storage.Local/src/FileInfoBasedCreationDateExtractor.cs
@@ -8,6 +8,6 @@ public class FileInfoBasedCreationDateExtractor : IFileCreationDateExtractor
 {
     public virtual DateTime ExtractCreationDate(FileInfo file)
     {
-        return file.CreationTimeUtc > file.LastWriteTimeUtc ? file.LastWriteTimeUtc : file.CreationTimeUtc;
+        return file.CreationTime > file.LastWriteTime ? file.LastWriteTime : file.CreationTime;
     }
 }

--- a/src/MediaOrganizer.Storage.Local/test/MediaOrganizer.Storage.Local.Tests/ExifCreationDateExtractorTests.cs
+++ b/src/MediaOrganizer.Storage.Local/test/MediaOrganizer.Storage.Local.Tests/ExifCreationDateExtractorTests.cs
@@ -1,0 +1,42 @@
+using MediaOrganizer.Storage.Local;
+
+namespace MediaOrganizer.Storage.Local.Tests;
+
+public class ExifCreationDateExtractorTests
+{
+    [Fact]
+    public void TryParseMetadataTimestamp_ShouldPreserveExifDateWithoutAssumingUtc()
+    {
+        var result = ExifCreationDateExtractor.TryParseMetadataTimestamp("2025:04:01 00:30:00", out var captureDate);
+
+        Assert.True(result);
+        Assert.Equal(new DateTime(2025, 4, 1, 0, 30, 0), captureDate);
+        Assert.Equal(DateTimeKind.Unspecified, captureDate.Kind);
+    }
+
+    [Fact]
+    public void TryParseMetadataTimestamp_ShouldPreserveOffsetAwareCalendarDate()
+    {
+        var result = ExifCreationDateExtractor.TryParseMetadataTimestamp("Tue Apr 01 00:30:00 +09:00 2025", out var captureDate);
+
+        Assert.True(result);
+        Assert.Equal(new DateTime(2025, 4, 1, 0, 30, 0), captureDate);
+    }
+
+    [Fact]
+    public void TryParseMetadataTimestamp_ShouldSupportGeneralOffsetParsingWithoutUtcShift()
+    {
+        var result = ExifCreationDateExtractor.TryParseMetadataTimestamp("2025-04-01T00:30:00+09:00", out var captureDate);
+
+        Assert.True(result);
+        Assert.Equal(new DateTime(2025, 4, 1, 0, 30, 0), captureDate);
+    }
+
+    [Fact]
+    public void TryParseMetadataTimestamp_ShouldReturnFalseForUnknownFormat()
+    {
+        var result = ExifCreationDateExtractor.TryParseMetadataTimestamp("not-a-date", out _);
+
+        Assert.False(result);
+    }
+}


### PR DESCRIPTION
## Summary
- preserve EXIF-recorded calendar dates instead of converting them to UTC before folder generation
- use local filesystem timestamps for fallback date extraction to avoid UTC day-boundary shifts
- add regression tests for naive EXIF timestamps and offset-aware metadata parsing

## Testing
- dotnet test .\\src\\MediaOrganizer.Storage.Local\\test\\MediaOrganizer.Storage.Local.Tests\\MediaOrganizer.Storage.Local.Tests.csproj --nologo